### PR TITLE
Fix a bug where we put trailing newlines in their own groups

### DIFF
--- a/matl_online/matl.py
+++ b/matl_online/matl.py
@@ -142,11 +142,14 @@ def parse_matl_results(output):
     """
     result = list()
 
-    parts = re.split('(\[.*?\][^\n].*)', output)
+    parts = re.split('(\[.*?\][^\n].*\n?)', output)
 
     for part in parts:
         if part == '':
             continue
+
+        # Strip a single trailing newline
+        part = part.rstrip('\n')
 
         item = dict()
 

--- a/tests/test_log_handler.py
+++ b/tests/test_log_handler.py
@@ -145,9 +145,8 @@ class TestLogHandler:
 
         event, payload = emit.call_args[0]
 
-        # TODO: Look into if we really want a trailing newline here
         expected_data = {'session': identifier,
-                         'data': [{'type': 'stdout', 'value': 'test1\n'},
+                         'data': [{'type': 'stdout', 'value': 'test1'},
                                   {'type': 'stderr', 'value': 'error'}]}
 
         assert payload == expected_data


### PR DESCRIPTION
This caused unnecessary vertical whitespace when displaying multiple images because we were sending these newlines through to the `<pre>` tag to be displayed

Now we just include them in the split group and then strip them off inside of the processing loop.