### PR TITLE
Use strings for data URLs rather than bytes

### DIFF
--- a/matl_online/matl.py
+++ b/matl_online/matl.py
@@ -140,7 +140,7 @@ def process_image(image_path, interpolation=False):
     if os.path.isfile(image_path):
         return ({
             'type': 'image' if interpolation else 'image_nn',
-            'value': b'data:image/png;' + base64_encode_file(image_path)
+            'value': 'data:image/png;' + base64_encode_file(image_path)
         })
 
 
@@ -149,7 +149,7 @@ def process_audio(audio_file):
     if os.path.isfile(audio_file):
         return {
             'type': 'audio',
-            'value': b'data:audio/wav;' + base64_encode_file(audio_file)
+            'value': 'data:audio/wav;' + base64_encode_file(audio_file)
         }
 
 

--- a/matl_online/utils.py
+++ b/matl_online/utils.py
@@ -12,7 +12,7 @@ ISO8601_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 def base64_encode_file(filename):
     """Load a file and return the base64-encoded version of the contents."""
     with open(filename, 'rb') as fid:
-        return b'base64,' + base64.b64encode(fid.read())
+        return 'base64,' + base64.b64encode(fid.read()).decode()
 
 
 def parse_iso8601(date):

--- a/tests/test_matl.py
+++ b/tests/test_matl.py
@@ -176,8 +176,8 @@ class TestResults:
         assert result[0]['type'] == 'image_nn'
 
         # Since the file is empty it should just be the header portion
-        encoded = base64.b64encode(contents)
-        assert result[0]['value'] == b'data:image/png;base64,' + encoded
+        encoded = base64.b64encode(contents).decode()
+        assert result[0]['value'] == 'data:image/png;base64,' + encoded
 
         # Make sure the file was not removed
         assert os.path.isfile(fileobj.strpath)
@@ -196,8 +196,8 @@ class TestResults:
         assert result[0]['type'] == 'image'
 
         # Since the file is empty it should just be the header portion
-        encoded = base64.b64encode(contents)
-        assert result[0]['value'] == b'data:image/png;base64,' + encoded
+        encoded = base64.b64encode(contents).decode()
+        assert result[0]['value'] == 'data:image/png;base64,' + encoded
 
         # Make sure the file was not removed
         assert os.path.isfile(fileobj.strpath)
@@ -223,8 +223,8 @@ class TestResults:
         assert len(result) == 1
         assert result[0]['type'] == 'audio'
 
-        encoded = base64.b64encode(contents)
-        assert result[0]['value'] == b'data:audio/wav;base64,' + encoded
+        encoded = base64.b64encode(contents).decode()
+        assert result[0]['value'] == 'data:audio/wav;base64,' + encoded
 
         # Make sure that the file was not removed
         assert os.path.isfile(fileobj.strpath)


### PR DESCRIPTION
Previously we were returning `bytes` which are not able to be serialized to JSON. Rather than using `bytes`, we should convert the output of `base64.b64encode` to a string.