### PR TITLE
Update octave evaluation to use line_handler rather than stream_handler [Fixes #270]

### DIFF
--- a/matl_online/matl.py
+++ b/matl_online/matl.py
@@ -190,7 +190,7 @@ def parse_matl_results(output):
     return result
 
 
-def matl(octave, flags, code='', inputs='', version='', folder='', stream_handler=None):
+def matl(octave, flags, code='', inputs='', version='', folder='', line_handler=None):
     """Open a session with Octave and manages input/output as well as errors."""
     # Remember what directory octave is current in
     def escape(x):
@@ -216,7 +216,7 @@ def matl(octave, flags, code='', inputs='', version='', folder='', stream_handle
         cmd = "matl_runner('%s', %s);\n" % (flags, code)
 
     # Actually run the MATL code
-    octave.eval(cmd, stream_handler=stream_handler)
+    octave.eval(cmd, line_handler=line_handler)
 
     # Change back to the original directory
     cmd = "cd('%s')" % escape(current_app.config['PROJECT_ROOT'])

--- a/matl_online/octave.py
+++ b/matl_online/octave.py
@@ -33,8 +33,8 @@ class OctaveSession:
 
     def eval(self, code, **kwargs):
         """Evaluate some code in Octave."""
-        handler = kwargs.pop('stream_handler', self._engine.stream_handler)
-        self._engine.stream_handler = handler
+        handler = kwargs.pop('line_handler', self._engine.line_handler)
+        self._engine.line_handler = handler
         return self._engine.eval(code, **kwargs)
 
     def restart(self):

--- a/matl_online/tasks.py
+++ b/matl_online/tasks.py
@@ -182,7 +182,7 @@ def matl_task(self, *args, **kwargs):
 
     try:
         matl(self.octave, *args, folder=self.folder,
-             stream_handler=self.handler.process_message, **kwargs)
+             line_handler=self.handler.process_message, **kwargs)
         result = self.send_results()
 
     # In the case of an interrupt (either through a time limit or a

--- a/tests/test_octave.py
+++ b/tests/test_octave.py
@@ -69,9 +69,9 @@ class TestOctaveSession:
         output_list = list()
         handler = output_list.append
 
-        session.eval(code, stream_handler=handler)
+        session.eval(code, line_handler=handler)
 
-        assert session._engine.stream_handler == handler
+        assert session._engine.line_handler == handler
         mock.assert_called_with(code)
 
     def test_terminate(self, mocker):


### PR DESCRIPTION
The `stream_handler` now has trailing newlines, etc. whereas the behavior of `line_handler` is more similar to what `stream_handler` used to be.

Additionally adds some tests to ensure that we don't have future regressions.