### PR TITLE
Remove support for Python 3.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,6 @@ workflows:
       - integration-tests
   test:
     jobs:
-      - test-3.7
       - test-3.8
       - test-3.9
 jobs:
@@ -18,9 +17,9 @@ jobs:
       - run:
           name: Run Integreation Tests
           command: make integration-tests
-  test-3.7: &test-template
+  test-3.8: &test-template
     docker:
-      - image: circleci/python:3.7-buster
+      - image: circleci/python:3.8-buster
     working_directory: ~/repo
     steps:
       - checkout
@@ -58,10 +57,6 @@ jobs:
           name: Report Coverage
           command: |
             coveralls
-  test-3.8:
-    <<: *test-template
-    docker:
-      - image: circleci/python:3.8-buster
   test-3.9:
     <<: *test-template
     docker:


### PR DESCRIPTION
Some of our dependencies now rely on 3.8+ so go ahead and remove support for 3.7 in testing