### PR TITLE
Use config option for setting the timeout for a process to be alive

### DIFF
--- a/matl_online/extensions.py
+++ b/matl_online/extensions.py
@@ -1,16 +1,10 @@
 """Enable third party extensions."""
 
 from celery import Celery
-from celery.concurrency import asynpool  # type: ignore
 from flask_migrate import Migrate  # type: ignore
 from flask_socketio import SocketIO  # type: ignore
 from flask_sqlalchemy import SQLAlchemy
 from flask_wtf import CSRFProtect  # type: ignore
-
-from matl_online.settings import Config
-
-# Change the timeout for celery process initialization
-asynpool.PROC_ALIVE_TIMEOUT = Config.CELERY_PROCESS_INIT_TIMEOUT
 
 db = SQLAlchemy()
 migrate = Migrate()

--- a/matl_online/settings.py
+++ b/matl_online/settings.py
@@ -21,9 +21,6 @@ class Config(object):
 
     ENV: str = "NONE"
 
-    # Custom timeout for celery process initialization
-    CELERY_PROCESS_INIT_TIMEOUT = 10
-
     IMGUR_CLIENT_ID = os.environ.get("MATL_ONLINE_IMGUR_CLIENT_ID")
 
     SECRET_KEY = str(uuid.uuid4())
@@ -125,6 +122,8 @@ def get_celery_configuration(configuration: FlaskConfig) -> Dict[str, Any]:
         ),
         "task_soft_time_limit": 30,
         "task_time_limit": 60,
+        # Custom timeout for celery process initialization
+        "worker_proc_alive_timeout": 30,
         # Ensure that celery tasks are executed locally when in a test environment
         "task_always_eager": configuration.get("ENV") == "test",
         # Use pickling for serialization to allow first-class objects rather than dicts.


### PR DESCRIPTION
Previously there was not a configuration option to specify the celery worker init timeout and the hack no longer worked causing the celery workers to get stuck since Octave typically takes longer than the default 4 seconds to boot. This change uses the official configuration option introduced in Celery 4 to configure the worker init timeout