### PR TITLE
Use app image for flower deployment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,10 +42,14 @@ services:
       - redis
 
   flower:
-    image: mher/flower
+    build:
+      context: .
+      dockerfile: ops/Dockerfile
     environment:
       CELERY_BROKER_URL: redis://redis:6379
       CELERY_RESULT_BACKEND: redis://redis:6379
+      MATL_ONLINE_ENV: prod
+    command: celery --app worker.celery flower
     ports:
       - "5555:5555"
     depends_on:

--- a/ops/templates/flower/deployment.yaml
+++ b/ops/templates/flower/deployment.yaml
@@ -18,9 +18,10 @@ spec:
     spec:
       containers:
         - name: web
-          image: "mher/flower:1.2"
+          image: "suever/matl-online:{{ .Values.CommitHash }}"
           command:
             - celery
+            - --app=worker.celery
             - flower
             - --auth-provider=flower.views.auth.GithubLoginHandler
           ports:
@@ -30,6 +31,10 @@ spec:
               value: "admin"
             - name: FLOWER_PORT
               value: "5555"
+            - name: FLOWER_DB
+              value: "/data/flower"
+            - name: FLOWER_PERSISTENT
+              value: "True"
             - name: FLOWER_AUTH
               valueFrom:
                 secretKeyRef:
@@ -57,6 +62,11 @@ spec:
                 secretKeyRef:
                   key: REDIS_URL
                   name: secrets
+            - name: MATL_ONLINE_ENV
+              value: prod
+          volumeMounts:
+            - name: data
+              mountPath: "/data"
           securityContext:
             runAsNonRoot: true
             runAsUser: 8877
@@ -73,3 +83,9 @@ spec:
             limits:
               cpu: 200m
               memory: 256Mi
+      securityContext:
+        fsGroup: 8877
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: flower-pvc

--- a/ops/templates/flower/pvc.yaml
+++ b/ops/templates/flower/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: flower-pvc
+  namespace: matl-online
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 256Mi

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -18,6 +18,7 @@ python_socketio==5.7.2
 
 # Celery
 celery==5.2.7
+flower==1.2.0
 redis==4.5.1
 
 # Octave interaction


### PR DESCRIPTION
We need the app-specific configuration so we can just use the app image that we already have. Also, we add a persistent DB to keep stats around after restarts