### PR TITLE
Revert "Bump ipython from 9.5.0 to 9.6.0"

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -23,7 +23,7 @@ redis==6.4.0
 scipy==1.16.2
 numpy==2.3.3
 octave-kernel==0.36.0
-ipython==9.6.0
+ipython==9.5.0
 
 # Octave packages
 sympy==1.5.1


### PR DESCRIPTION
Reverts suever/MATL-Online#1309